### PR TITLE
Fix PHP 5.4 syntax

### DIFF
--- a/ext/php/phpext.c
+++ b/ext/php/phpext.c
@@ -198,7 +198,7 @@ static int psex_determine_array_type(HashTable *myht TSRMLS_DC) /* {{{ */
 
 
 
-function_entry syck_functions[] = {
+zend_function_entry syck_functions[] = {
 	PHP_FE(syck_load, arginfo_syck_load)
 	PHP_FE(syck_dump, arginfo_syck_dump)
 	{NULL, NULL, NULL}	/* Must be the last line in syck_functions[] */
@@ -403,7 +403,7 @@ SYMID php_syck_handler(SyckParser *p, SyckNode *n)
 
 				strncpy(classname, n->type_id + 12, classname_len + 1);
 
-				if (FAILURE == zend_lookup_class_ex(classname, classname_len, 1, &ce TSRMLS_CC)) {
+				if (FAILURE == zend_lookup_class(classname, classname_len, &ce TSRMLS_CC)) {
 					zend_throw_exception_ex(syck_exception_entry, 0 TSRMLS_CC, "Couldn't find %s class on line %d, col %d: '%s'", classname, p->linect + 1, p->cursor - p->lineptr, p->lineptr);
 					efree(classname);
 					break;
@@ -439,7 +439,7 @@ SYMID php_syck_handler(SyckParser *p, SyckNode *n)
 
 				strncpy(classname, n->type_id + 11, classname_len + 1);
 
-				if (FAILURE == zend_lookup_class_ex(classname, classname_len, 1, &ce TSRMLS_CC)) {
+				if (FAILURE == zend_lookup_class(classname, classname_len, &ce TSRMLS_CC)) {
 					zend_throw_exception_ex(syck_exception_entry, 0 TSRMLS_CC, "Couldn't find %s class on line %d, col %d: '%s'", classname, p->linect + 1, p->cursor - p->lineptr, p->lineptr);
 					efree(classname);
 					break;
@@ -511,7 +511,7 @@ SYMID php_syck_handler(SyckParser *p, SyckNode *n)
 
 				strncpy(classname, n->type_id + 10, classname_len + 1);
 
-				if (FAILURE == zend_lookup_class_ex(classname, classname_len, 1, &ce TSRMLS_CC)) {
+				if (FAILURE == zend_lookup_class(classname, classname_len, &ce TSRMLS_CC)) {
 					zend_throw_exception_ex(syck_exception_entry, 0 TSRMLS_CC, "Couldn't find %s class on line %d, col %d: '%s'", classname, p->linect + 1, p->cursor - p->lineptr, p->lineptr);
 					efree(classname);
 					break;


### PR DESCRIPTION
function_entry is removed in php 5.4
zend_function entry should be used instead (available since php 5.0.0)

zend_lookup_class_ex requires a new parameter (const zend_literal *key) while zend_lookup_class is the same (and use autoload=1 as default)

Patch tested against php 5.4.0RC5-dev.
Should not break build against older version.
