### PR TITLE
Build syck as a shared library.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,6 @@
 #
 # I feel like saying, "The magic happens here!"  But it doesn't.
 #
+ACLOCAL_AMFLAGS = -I m4
 SUBDIRS = lib tests
 

--- a/bootstrap
+++ b/bootstrap
@@ -4,4 +4,5 @@ set -x
 aclocal
 autoheader
 autoconf
+libtoolize
 automake --foreign --add-missing --copy

--- a/configure.in
+++ b/configure.in
@@ -3,6 +3,9 @@ AC_INIT(syck, 0.70)
 AC_CONFIG_AUX_DIR(config)
 AC_PREREQ(2.50)
 
+LT_INIT
+AC_SUBST([SYCK_SO_VERSION], [0:0:0])
+
 AM_INIT_AUTOMAKE(syck, 0.70)
 AM_CONFIG_HEADER(config.h)
 
@@ -10,10 +13,12 @@ AM_CONFIG_HEADER(config.h)
 AC_PROG_CC_STDC
 AC_PROG_INSTALL
 AC_PROG_LN_S
-AC_PROG_RANLIB
+# `AC_PROG_RANLIB' is rendered obsolete by `LT_INIT'
+# AC_PROG_RANLIB
 AC_PROG_MAKE_SET
 AC_PROG_AWK
 AM_PROG_LEX
+AC_PROG_LIBTOOL
 
 AC_CHECK_PROGS(YACC, 'bison -y')
 if test "$YACC" != "bison -y"; then
@@ -33,7 +38,7 @@ AC_CHECK_SIZEOF(long, 4)
 # Checks for library functions.
 AC_FUNC_MALLOC
 AC_FUNC_VPRINTF
-
+AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_FILES([Makefile 
                  lib/Makefile 
                  tests/Makefile])

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -7,6 +7,7 @@ AM_CFLAGS = -fPIC
 .re.c:
 	$(REC) -i $< > $@.new && mv $@.new $@
 
+lib_LTLIBRARIES = libsyck.la
 lib_LIBRARIES = libsyck.a
 include_HEADERS = syck.h syck_st.h
 
@@ -21,4 +22,8 @@ libsyck_a_SOURCES = \
 	yaml2byte.c \
 	token.re \
 	implicit.re
+
+libsyck_la_CFLAGS = $(AM_CFLAGS)
+libsyck_la_LDFLAGS = -version-info $(SYCK_SO_VERSION)
+libsyck_la_SOURCES = $(libsyck_a_SOURCES)
 


### PR DESCRIPTION
Build syck also as a shared library. 

In my case it is easier to use syck as a shared library in HsSyck as ghc does not work well with static libraries.
